### PR TITLE
Add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .DS_Store
 *.csv
 index.js
+coverage
+.nyc_output

--- a/package-lock.json
+++ b/package-lock.json
@@ -329,6 +329,12 @@
         }
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -489,6 +495,12 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
       "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "optional": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -653,6 +665,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "docdash": {
@@ -1882,6 +1900,12 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1934,6 +1958,12 @@
           }
         }
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -2569,6 +2599,65 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "morgan": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,48 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/generator": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
+      "integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.2.2",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
     "@babel/highlight": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -22,6 +64,51 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
+      "integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/types": "^7.2.2"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.2.2",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.2.3",
+        "@babel/types": "^7.2.2",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "@babel/types": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
+      "integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@blakeembrey/deque": {
@@ -2304,6 +2391,27 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
+      "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "istanbul-lib-coverage": "^2.0.1",
+        "semver": "^5.5.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2348,6 +2456,12 @@
         "taffydb": "2.6.2",
         "underscore": "~1.8.3"
       }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -2830,6 +2944,1145 @@
             "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
             "path-type": "^3.0.0"
+          }
+        }
+      }
+    },
+    "nyc": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
+      "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^2.0.0",
+        "convert-source-map": "^1.6.0",
+        "debug-log": "^1.0.1",
+        "find-cache-dir": "^2.0.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.1",
+        "istanbul-lib-hook": "^2.0.1",
+        "istanbul-lib-instrument": "^3.0.0",
+        "istanbul-lib-report": "^2.0.2",
+        "istanbul-lib-source-maps": "^2.0.1",
+        "istanbul-reports": "^2.0.1",
+        "make-dir": "^1.3.0",
+        "merge-source-map": "^1.1.0",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^5.0.0",
+        "uuid": "^3.3.2",
+        "yargs": "11.1.0",
+        "yargs-parser": "^9.0.2"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "^2.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "make-dir": "^1.0.0",
+            "md5-hex": "^2.0.0",
+            "package-hash": "^2.0.0",
+            "write-file-atomic": "^2.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es6-error": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "^1.0.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^2.0.1",
+            "make-dir": "^1.3.0",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^2.0.1",
+            "make-dir": "^1.3.0",
+            "rimraf": "^2.6.2",
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.0.11"
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "md5-hex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "^0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.10",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "package-hash": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "lodash.flattendeep": "^4.4.0",
+            "md5-hex": "^2.0.0",
+            "release-zalgo": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "release-zalgo": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es6-error": "^4.0.1"
+          }
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "minimatch": "^3.0.4",
+            "read-pkg-up": "^4.0.0",
+            "require-main-filename": "^1.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            }
           }
         }
       }
@@ -3894,6 +5147,12 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -3940,6 +5199,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
       "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "zebras.js",
   "unpkg": "zebras.js",
   "scripts": {
-    "test": "mocha --reporter spec",
+    "test": "nyc --reporter=html --reporter=text mocha --timeout=3000",
     "build:docs": "jsdoc --configure .jsdoc.json",
     "watch:docs": "onchange 'zebras.js' -- npm run build:docs",
     "watch:test": "onchange 'test/*.js' -- npm run test",
@@ -35,8 +35,9 @@
     "eslint-plugin-import": "^2.14.0",
     "jsdoc": "^3.5.5",
     "live-server": "^1.2.1",
-    "npm-run-all": "^4.1.5",
     "mocha": "^5.2.0",
+    "npm-run-all": "^4.1.5",
+    "nyc": "^13.1.0",
     "onchange": "^5.2.0",
     "prettier": "^1.15.3"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "zebras.js",
   "unpkg": "zebras.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha --reporter spec",
     "build:docs": "jsdoc --configure .jsdoc.json",
     "watch:docs": "onchange 'zebras.js' -- npm run build:docs",
     "serve:docs": "live-server ./docs",
@@ -35,6 +35,7 @@
     "jsdoc": "^3.5.5",
     "live-server": "^1.2.1",
     "npm-run-all": "^4.1.5",
+    "mocha": "^5.2.0",
     "onchange": "^5.2.0",
     "prettier": "^1.15.3"
   },
@@ -50,7 +51,9 @@
   "eslintConfig": {
     "extends": "airbnb-base",
     "rules": {
-      "semi": "never"
+      "semi": "off",
+      "quotes": "double",
+      "arrow-parens": "as-needed"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "mocha --reporter spec",
     "build:docs": "jsdoc --configure .jsdoc.json",
     "watch:docs": "onchange 'zebras.js' -- npm run build:docs",
+    "watch:test": "onchange 'test/*.js' -- npm run test",
     "serve:docs": "live-server ./docs",
     "dev:docs": "npx run-p watch:docs serve:docs"
   },

--- a/test/addCol.js
+++ b/test/addCol.js
@@ -1,0 +1,20 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("addCol", function() {
+  it("adds a new column to a dataframe from an array", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "B", value: 2 },
+      { label: "C", value: 75 },
+    ]
+    const series = ["2010-12-15", "2010-12-16", "2010-12-17"]
+
+    assert.deepStrictEqual(Z.addCol("date", series, df), [
+      { date: "2010-12-15", label: "A", value: 7 },
+      { date: "2010-12-16", label: "B", value: 2 },
+      { date: "2010-12-17", label: "C", value: 75 },
+    ])
+  })
+})

--- a/test/addCol.js
+++ b/test/addCol.js
@@ -3,18 +3,24 @@ const assert = require("assert")
 const Z = require("../zebras.js")
 
 describe("addCol", function() {
+  const df = [
+    { label: "A", value: 7 },
+    { label: "B", value: 2 },
+    { label: "C", value: 75 },
+  ]
+  const series = ["2010-12-15", "2010-12-16", "2010-12-17"]
   it("adds a new column to a dataframe from an array", function() {
-    const df = [
-      { label: "A", value: 7 },
-      { label: "B", value: 2 },
-      { label: "C", value: 75 },
-    ]
-    const series = ["2010-12-15", "2010-12-16", "2010-12-17"]
-
     assert.deepStrictEqual(Z.addCol("date", series, df), [
       { date: "2010-12-15", label: "A", value: 7 },
       { date: "2010-12-16", label: "B", value: 2 },
       { date: "2010-12-17", label: "C", value: 75 },
     ])
+  })
+  it("returns error message when arrays don't have equal length", function() {
+    const series = ["2010-12-15"]
+    assert.strictEqual(
+      Z.addCol("date", series, df),
+      "Arrays are not of equal length"
+    )
   })
 })

--- a/test/concat.js
+++ b/test/concat.js
@@ -1,0 +1,16 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("concat", function() {
+  it("concatenates two dataframes", function() {
+    const df1 = [{ label: "A", value: 7 }, { label: "B", value: 2 }]
+    const df2 = [{ label: "C", value: 17 }, { label: "D", value: 2 }]
+    assert.deepStrictEqual(Z.concat(df1, df2), [
+      { label: "A", value: 7 },
+      { label: "B", value: 2 },
+      { label: "C", value: 17 },
+      { label: "D", value: 2 },
+    ])
+  })
+})

--- a/test/corr.js
+++ b/test/corr.js
@@ -1,0 +1,12 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("corr", function() {
+  it("returns correlation of two series", function() {
+    assert.strictEqual(
+      Z.corr([10, 15, 20, 25, 50, 55], [12, 18, 34, 52, 71, 86]),
+      0.969035563335365
+    )
+  })
+})

--- a/test/corr.js
+++ b/test/corr.js
@@ -9,4 +9,10 @@ describe("corr", function() {
       0.969035563335365
     )
   })
+  it("returns error message when arrays don't have equal length", function() {
+    assert.strictEqual(
+      Z.corr([10, 15, 20, 25, 50, 55], [34, 52, 71, 86]),
+      "Arrays are not the same length"
+    )
+  })
 })

--- a/test/countUnique.js
+++ b/test/countUnique.js
@@ -1,0 +1,9 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("countUnique", function() {
+  it("returns number of unique values in the array", function() {
+    assert.deepStrictEqual(Z.countUnique([7, 7, 2, 30, 30, 56, 75]), 5)
+  })
+})

--- a/test/cumulative.js
+++ b/test/cumulative.js
@@ -1,0 +1,17 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("cumulative", function() {
+  it("calculates cumulative statistics", function() {
+    const series = [7, 2, 30, 30, 56, 75]
+    assert.deepStrictEqual(Z.cumulative(Z.mean, series), [
+      7,
+      4.5,
+      13,
+      17.25,
+      25,
+      33.333333333333336,
+    ])
+  })
+})

--- a/test/deriveCol.js
+++ b/test/deriveCol.js
@@ -1,0 +1,15 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("deriveCol", function() {
+  it("creates a new dataframe based on columns from existing dataframe.", function() {
+    const temps = [
+      { date: "1990-05-06", tempCelsius: 0 },
+      { date: "1990-05-07", tempCelsius: 4 },
+    ]
+    const fahrenheit = r => r.tempCelsius * 1.8 + 32
+
+    assert.deepStrictEqual(Z.deriveCol(fahrenheit, temps), [32, 39.2])
+  })
+})

--- a/test/describe.js
+++ b/test/describe.js
@@ -1,0 +1,20 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("describe", function() {
+  it("returns summary statistis", function() {
+    const series = [7, 2, 30, 30, 56, 75]
+    assert.deepStrictEqual(Z.describe(series), [
+      {
+        count: 6,
+        countUnique: 5,
+        max: "75.00000",
+        mean: "33.33333",
+        median: "30.00000",
+        min: "2.00000",
+        std: "28.09745",
+      },
+    ])
+  })
+})

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,0 +1,24 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("diff", function() {
+  it("calculates differences between values in the order of the input series", function() {
+    assert.deepStrictEqual(Z.diff([7, 2, 30, 30, 56, 75]), [
+      NaN,
+      -5,
+      28,
+      0,
+      26,
+      19,
+    ])
+    assert.deepStrictEqual(Z.diff([0]), [NaN])
+    assert.deepStrictEqual(Z.diff([0, "not a number"]), [NaN, NaN])
+    assert.deepStrictEqual(Z.diff([0, "not a number", 1, 3]), [
+      NaN,
+      NaN,
+      NaN,
+      2,
+    ])
+  })
+})

--- a/test/dropCol.js
+++ b/test/dropCol.js
@@ -1,0 +1,18 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("dropCol", function() {
+  it("deletes a column", function() {
+    const df = [
+      { label: "A", value: 10, date: "2010-12-13" },
+      { label: "B", value: 13, date: "2010-12-15" },
+      { label: "C", value: 15, date: "2010-12-17" },
+    ]
+    assert.deepStrictEqual(Z.dropCol("date", df), [
+      { label: "A", value: 10 },
+      { label: "B", value: 13 },
+      { label: "C", value: 15 },
+    ])
+  })
+})

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,0 +1,17 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("filter", function() {
+  it("filters dataframe rows according to a filtering function", function() {
+    const df = [
+      { label: "A", value: 2 },
+      { label: "B", value: 10 },
+      { label: "C", value: 30 },
+    ]
+    assert.deepStrictEqual(Z.filter(r => r.value >= 10, df), [
+      { label: "B", value: 10 },
+      { label: "C", value: 30 },
+    ])
+  })
+})

--- a/test/gbCount.js
+++ b/test/gbCount.js
@@ -1,0 +1,21 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("gbCount", function() {
+  it("calculates count for grouped objects", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "A", value: 3 },
+      { label: "B", value: 2 },
+      { label: "B", value: 5 },
+      { label: "C", value: 75 },
+    ]
+    const result = Z.gbCount("value", Z.groupBy(d => d.label, df))
+    assert.deepStrictEqual(result, [
+      { count: 2, group: "A" },
+      { count: 2, group: "B" },
+      { count: 1, group: "C" },
+    ])
+  })
+})

--- a/test/gbDescribe.js
+++ b/test/gbDescribe.js
@@ -1,0 +1,37 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("gbDescribe", function() {
+  it("calculates count for grouped objects", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "A", value: 3 },
+      { label: "B", value: 2 },
+      { label: "B", value: 5 },
+      { label: "C", value: 75 },
+    ]
+    const result = Z.gbDescribe("value", Z.groupBy(d => d.label, df))
+    assert.deepStrictEqual(result, [
+      {
+        count: 2,
+        group: "A",
+        max: 7,
+        mean: 5,
+        min: 3,
+        std: 2.8284271247461903,
+        sum: 10,
+      },
+      {
+        count: 2,
+        group: "B",
+        max: 5,
+        mean: 3.5,
+        min: 2,
+        std: 2.1213203435596424,
+        sum: 7,
+      },
+      { count: 1, group: "C", max: 75, mean: 75, min: 75, std: NaN, sum: 75 },
+    ])
+  })
+})

--- a/test/gbDescribe.js
+++ b/test/gbDescribe.js
@@ -3,7 +3,7 @@ const assert = require("assert")
 const Z = require("../zebras.js")
 
 describe("gbDescribe", function() {
-  it("calculates count for grouped objects", function() {
+  it("returns summary statistis for grouped objects", function() {
     const df = [
       { label: "A", value: 7 },
       { label: "A", value: 3 },

--- a/test/gbMax.js
+++ b/test/gbMax.js
@@ -1,0 +1,21 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("gbMax", function() {
+  it("calculates count for grouped objects", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "A", value: 3 },
+      { label: "B", value: 2 },
+      { label: "B", value: 5 },
+      { label: "C", value: 75 },
+    ]
+    const result = Z.gbMax("value", Z.groupBy(d => d.label, df))
+    assert.deepStrictEqual(result, [
+      { group: "A", max: 7 },
+      { group: "B", max: 5 },
+      { group: "C", max: 75 },
+    ])
+  })
+})

--- a/test/gbMax.js
+++ b/test/gbMax.js
@@ -3,7 +3,7 @@ const assert = require("assert")
 const Z = require("../zebras.js")
 
 describe("gbMax", function() {
-  it("calculates count for grouped objects", function() {
+  it("calculates max for grouped objects", function() {
     const df = [
       { label: "A", value: 7 },
       { label: "A", value: 3 },

--- a/test/gbMean.js
+++ b/test/gbMean.js
@@ -1,0 +1,21 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("gbMean", function() {
+  it("calculates mean for grouped objects", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "A", value: 3 },
+      { label: "B", value: 2 },
+      { label: "B", value: 5 },
+      { label: "C", value: 75 },
+    ]
+    const result = Z.gbMean("value", Z.groupBy(d => d.label, df))
+    assert.deepStrictEqual(result, [
+      { group: "A", mean: 5 },
+      { group: "B", mean: 3.5 },
+      { group: "C", mean: 75 },
+    ])
+  })
+})

--- a/test/gbMin.js
+++ b/test/gbMin.js
@@ -1,0 +1,21 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("gbMin", function() {
+  it("calculates count for grouped objects", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "A", value: 3 },
+      { label: "B", value: 2 },
+      { label: "B", value: 5 },
+      { label: "C", value: 75 },
+    ]
+    const result = Z.gbMin("value", Z.groupBy(d => d.label, df))
+    assert.deepStrictEqual(result, [
+      { group: "A", min: 3 },
+      { group: "B", min: 2 },
+      { group: "C", min: 75 },
+    ])
+  })
+})

--- a/test/gbMin.js
+++ b/test/gbMin.js
@@ -3,7 +3,7 @@ const assert = require("assert")
 const Z = require("../zebras.js")
 
 describe("gbMin", function() {
-  it("calculates count for grouped objects", function() {
+  it("calculates min for grouped objects", function() {
     const df = [
       { label: "A", value: 7 },
       { label: "A", value: 3 },

--- a/test/gbStd.js
+++ b/test/gbStd.js
@@ -1,0 +1,21 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("gbStd", function() {
+  it("calculates std for grouped objects", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "A", value: 3 },
+      { label: "B", value: 2 },
+      { label: "B", value: 5 },
+      { label: "C", value: 75 },
+    ]
+    const result = Z.gbStd("value", Z.groupBy(d => d.label, df))
+    assert.deepStrictEqual(result, [
+      { group: "A", std: 2.8284271247461903 },
+      { group: "B", std: 2.1213203435596424 },
+      { group: "C", std: NaN },
+    ])
+  })
+})

--- a/test/gbSum.js
+++ b/test/gbSum.js
@@ -1,0 +1,22 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("gbSum", function() {
+  it("calculates sums for grouped objects", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "A", value: 3 },
+      { label: "B", value: 2 },
+      { label: "B", value: 5 },
+      { label: "C", value: 75 },
+    ]
+    const result = Z.gbSum("value", Z.groupBy(d => d.label, df))
+    assert.strictEqual(result.length, 3)
+    assert.deepStrictEqual(result, [
+      { group: "A", sum: 10 },
+      { group: "B", sum: 7 },
+      { group: "C", sum: 75 },
+    ])
+  })
+})

--- a/test/getCol.js
+++ b/test/getCol.js
@@ -1,0 +1,18 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("getCol", function() {
+  it("extracts series to an array", function() {
+    const df = [
+      { label: "A", value: "2010-12-13" },
+      { label: "B", value: "2010-12-15" },
+      { label: "C", value: "2010-12-17" },
+    ]
+    assert.deepStrictEqual(Z.getCol("value", df), [
+      "2010-12-13",
+      "2010-12-15",
+      "2010-12-17",
+    ])
+  })
+})

--- a/test/getRange.js
+++ b/test/getRange.js
@@ -1,0 +1,11 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("getRange", function() {
+  it("returns the range of the array", function() {
+    assert.deepStrictEqual(Z.getRange([1, 2, 3, 4, 5]), [1, 5])
+    assert.deepStrictEqual(Z.getRange(["11", "2", "3", "4", "5"]), [2, 11])
+    assert.deepStrictEqual(Z.getRange([1, 2, "not a number", 4, 5]), [1, 5])
+  })
+})

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -1,0 +1,19 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("groupBy", function() {
+  it("creates an object grouped by according to the supplied function", function() {
+    assert.deepStrictEqual(
+      Z.groupBy(x => x.Day, [
+        { Day: "Monday", value: 10 },
+        { Day: "Tuesday", value: 5 },
+        { Day: "Monday", value: 7 },
+      ]),
+      {
+        Monday: [{ Day: "Monday", value: 10 }, { Day: "Monday", value: 7 }],
+        Tuesday: [{ Day: "Tuesday", value: 5 }],
+      }
+    )
+  })
+})

--- a/test/head.js
+++ b/test/head.js
@@ -1,0 +1,15 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("head", function() {
+  it("returns dataframe with first n rows of input dataframe", function() {
+    const df = [
+      { label: "A", value: "2010-12-13" },
+      { label: "B", value: "2010-12-15" },
+      { label: "C", value: "2010-12-17" },
+    ]
+    assert.deepStrictEqual(Z.head(2, df).length, 2)
+    assert.deepStrictEqual(Z.head(2, df).find(d => d.label === "C"), undefined)
+  })
+})

--- a/test/head.js
+++ b/test/head.js
@@ -9,7 +9,9 @@ describe("head", function() {
       { label: "B", value: "2010-12-15" },
       { label: "C", value: "2010-12-17" },
     ]
-    assert.deepStrictEqual(Z.head(2, df).length, 2)
-    assert.deepStrictEqual(Z.head(2, df).find(d => d.label === "C"), undefined)
+    assert.deepStrictEqual(Z.head(2, df), [
+      { label: "A", value: "2010-12-13" },
+      { label: "B", value: "2010-12-15" },
+    ])
   })
 })

--- a/test/kurt.js
+++ b/test/kurt.js
@@ -1,0 +1,9 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("kurt", function() {
+  it("returns kurtosis of series", function() {
+    assert.strictEqual(Z.kurt([7, 2, 30, 56, 75]), -2.040541067936147)
+  })
+})

--- a/test/max.js
+++ b/test/max.js
@@ -1,0 +1,11 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("max", function() {
+  it("returns the biggest value in the array", function() {
+    assert.strictEqual(Z.max([1, 2, 3, 4, 5]), 5)
+    assert.strictEqual(Z.max(["11", "2", "3", "4", "5"]), 11)
+    assert.strictEqual(Z.max([1, 2, "not a number", 4, 5]), 5)
+  })
+})

--- a/test/mean.js
+++ b/test/mean.js
@@ -1,0 +1,9 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("mean", function() {
+  it("returns mean of series", function() {
+    assert.strictEqual(Z.mean([7, 2, 30, 56, 75]), 34)
+  })
+})

--- a/test/median.js
+++ b/test/median.js
@@ -1,0 +1,9 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("median", function() {
+  it("returns median of series", function() {
+    assert.strictEqual(Z.median([7, 2, 30, 56, 75]), 30)
+  })
+})

--- a/test/merge.js
+++ b/test/merge.js
@@ -1,0 +1,27 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("merge", function() {
+  it("joins two dataframes on a column", function() {
+    const df1 = [
+      { label: "A", value: 7 },
+      { label: "B", value: 2 },
+      { label: "C", value: 75 },
+    ]
+    const df2 = [
+      { label: "A", value: "2010-12-13" },
+      { label: "B", value: "2010-12-15" },
+      { label: "C", value: "2010-12-17" },
+    ]
+
+    assert.deepStrictEqual(
+      Z.merge(df1, df2, "label", "label", "_df1", "_df2"),
+      [
+        { label: "A", value_df1: 7, value_df2: "2010-12-13" },
+        { label: "B", value_df1: 2, value_df2: "2010-12-15" },
+        { label: "C", value_df1: 75, value_df2: "2010-12-17" },
+      ]
+    )
+  })
+})

--- a/test/min.js
+++ b/test/min.js
@@ -1,0 +1,11 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("min", function() {
+  it("returns the smallest value in the array", function() {
+    assert.strictEqual(Z.min([1, 2, 3, 4, 5]), 1)
+    assert.strictEqual(Z.min(["11", "2", "3", "4", "5"]), 2)
+    assert.strictEqual(Z.min([1, 2, "not a number", 4, 5]), 1)
+  })
+})

--- a/test/parseDates.js
+++ b/test/parseDates.js
@@ -1,0 +1,18 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("parseDates", function() {
+  it("converts columns to datestamp", function() {
+    const df = [
+      { label: "A", value: "2010-12-13" },
+      { label: "B", value: "2010-12-15" },
+      { label: "C", value: "2010-12-17" },
+    ]
+    assert.deepStrictEqual(Z.parseDates(["value"], df), [
+      { label: "A", value: 1292198400000 },
+      { label: "B", value: 1292371200000 },
+      { label: "C", value: 1292544000000 },
+    ])
+  })
+})

--- a/test/parseNums.js
+++ b/test/parseNums.js
@@ -1,0 +1,18 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("parseNums", function() {
+  it("converts columns to numerical type (floats)", function() {
+    const df = [
+      { label: "A", value: "7" },
+      { label: "B", value: "-2" },
+      { label: "C", value: "75.43" },
+    ]
+    assert.deepStrictEqual(Z.parseNums(["value"], df), [
+      { label: "A", value: 7 },
+      { label: "B", value: -2 },
+      { label: "C", value: 75.43 },
+    ])
+  })
+})

--- a/test/pctChange.js
+++ b/test/pctChange.js
@@ -1,0 +1,16 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("pctChange", function() {
+  it("calculates percent changes between values in the order of the input series", function() {
+    assert.deepStrictEqual(Z.pctChange([10, 15, 20, 25, 50, 55]), [
+      NaN,
+      0.5,
+      0.33333333333333326,
+      0.25,
+      1,
+      0.10000000000000009,
+    ])
+  })
+})

--- a/test/pickCols.js
+++ b/test/pickCols.js
@@ -1,0 +1,18 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("pickCols", function() {
+  it("selects a subset of columns", function() {
+    const df = [
+      { label: "A", value: 10, date: "2010-12-13" },
+      { label: "B", value: 13, date: "2010-12-15" },
+      { label: "C", value: 15, date: "2010-12-17" },
+    ]
+    assert.deepStrictEqual(Z.pickCols(["label", "value"], df), [
+      { label: "A", value: 10 },
+      { label: "B", value: 13 },
+      { label: "C", value: 15 },
+    ])
+  })
+})

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,0 +1,19 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("pipe", function() {
+  it("pipes functions together by performing left-to-right function composition", function() {
+    const data = [
+      { Date: "1997-01-01", Value: "12" },
+      { Date: "1997-01-02", Value: "14" },
+      { Date: "1997-01-03", Value: "7" },
+      { Date: "1997-01-04", Value: "112" },
+    ]
+
+    assert.strictEqual(
+      Z.pipe([Z.parseNums(["Value"]), Z.getCol("Value"), Z.mean()])(data),
+      36.25
+    )
+  })
+})

--- a/test/print.js
+++ b/test/print.js
@@ -1,0 +1,15 @@
+const path = require("path")
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("print", function() {
+  it("prints dataframe as an ASCII table", function() {
+    const df = [{ label: "C", value: "3" }, { label: "B", value: "2" }]
+
+    assert.strictEqual(
+      Z.print(df),
+      "\n\u001b[90m┌───────\u001b[39m\u001b[90m┬───────┐\u001b[39m\n\u001b[90m│\u001b[39m\u001b[31m label \u001b[39m\u001b[90m│\u001b[39m\u001b[31m value \u001b[39m\u001b[90m│\u001b[39m\n\u001b[90m├───────\u001b[39m\u001b[90m┼───────┤\u001b[39m\n\u001b[90m│\u001b[39m C     \u001b[90m│\u001b[39m 3     \u001b[90m│\u001b[39m\n\u001b[90m├───────\u001b[39m\u001b[90m┼───────┤\u001b[39m\n\u001b[90m│\u001b[39m B     \u001b[90m│\u001b[39m 2     \u001b[90m│\u001b[39m\n\u001b[90m└───────\u001b[39m\u001b[90m┴───────┘\u001b[39m"
+    )
+  })
+})

--- a/test/printHead.js
+++ b/test/printHead.js
@@ -1,0 +1,15 @@
+const path = require("path")
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("printHead", function() {
+  it("prints first n rows of dataframe as an ASCII table", function() {
+    const df = [{ label: "C", value: "3" }, { label: "B", value: "2" }]
+
+    assert.strictEqual(
+      Z.printHead(1, df),
+      "\n\u001b[90m┌───────\u001b[39m\u001b[90m┬───────┐\u001b[39m\n\u001b[90m│\u001b[39m\u001b[31m label \u001b[39m\u001b[90m│\u001b[39m\u001b[31m value \u001b[39m\u001b[90m│\u001b[39m\n\u001b[90m├───────\u001b[39m\u001b[90m┼───────┤\u001b[39m\n\u001b[90m│\u001b[39m C     \u001b[90m│\u001b[39m 3     \u001b[90m│\u001b[39m\n\u001b[90m└───────\u001b[39m\u001b[90m┴───────┘\u001b[39m"
+    )
+  })
+})

--- a/test/printTail.js
+++ b/test/printTail.js
@@ -1,0 +1,15 @@
+const path = require("path")
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("printTail", function() {
+  it("prints last n rows of dataframe as an ASCII table", function() {
+    const df = [{ label: "C", value: "3" }, { label: "B", value: "2" }]
+
+    assert.strictEqual(
+      Z.printTail(1, df),
+      "\n\u001b[90m┌───────\u001b[39m\u001b[90m┬───────┐\u001b[39m\n\u001b[90m│\u001b[39m\u001b[31m label \u001b[39m\u001b[90m│\u001b[39m\u001b[31m value \u001b[39m\u001b[90m│\u001b[39m\n\u001b[90m├───────\u001b[39m\u001b[90m┼───────┤\u001b[39m\n\u001b[90m│\u001b[39m B     \u001b[90m│\u001b[39m 2     \u001b[90m│\u001b[39m\n\u001b[90m└───────\u001b[39m\u001b[90m┴───────┘\u001b[39m"
+    )
+  })
+})

--- a/test/prod.js
+++ b/test/prod.js
@@ -1,0 +1,11 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("prod", function() {
+  it("multplies array of numbers", function() {
+    assert.strictEqual(Z.prod([1, 2, 3, 4, 5]), 120)
+    assert.strictEqual(Z.prod(["1", "2", "3", "4", "5"]), 120)
+    assert.strictEqual(Z.prod([1, 2, "not a number", 4, 5]), 40)
+  })
+})

--- a/test/readCSV.js
+++ b/test/readCSV.js
@@ -1,0 +1,17 @@
+const path = require("path")
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("readCSV", function() {
+  it("synchronously reads a CSV file", function() {
+    assert.deepStrictEqual(
+      Z.readCSV(path.join(__dirname, "data/test_read.csv")),
+      [
+        { label: "A", value: "1" },
+        { label: "B", value: "2" },
+        { label: "C", value: "3" },
+      ]
+    )
+  })
+})

--- a/test/rolling.js
+++ b/test/rolling.js
@@ -1,0 +1,16 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("rolling", function() {
+  it("calculates rolling statistics", function() {
+    assert.deepStrictEqual(Z.rolling(Z.mean, 2, [7, 2, 30, 30, 56, 75]), [
+      "NotANumber",
+      4.5,
+      16,
+      30,
+      43,
+      65.5,
+    ])
+  })
+})

--- a/test/skew.js
+++ b/test/skew.js
@@ -1,0 +1,9 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("skew", function() {
+  it("returns skew of series", function() {
+    assert.strictEqual(Z.skew([7, 2, 30, 56, 75]), 0.17542841315728933)
+  })
+})

--- a/test/slice.js
+++ b/test/slice.js
@@ -1,0 +1,17 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("slice", function() {
+  it("gets dataframe rows by index", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "B", value: 2 },
+      { label: "C", value: 75 },
+    ]
+
+    assert.deepStrictEqual(Z.slice(1, 2, df), [{ label: "B", value: 2 }])
+    assert.deepStrictEqual(Z.slice(1, 1, df), [])
+    assert.deepStrictEqual(Z.slice(0, 3, df), df)
+  })
+})

--- a/test/sort.js
+++ b/test/sort.js
@@ -1,0 +1,18 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("sort", function() {
+  it("sorts dataframe rows according to a sorting function", function() {
+    const df = [
+      { label: "A", value: 7 },
+      { label: "B", value: 2 },
+      { label: "C", value: 75 },
+    ]
+    assert.deepStrictEqual(Z.sort((a, b) => b.value - a.value, df), [
+      { label: "C", value: 75 },
+      { label: "A", value: 7 },
+      { label: "B", value: 2 },
+    ])
+  })
+})

--- a/test/sortByCol.js
+++ b/test/sortByCol.js
@@ -1,0 +1,25 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("sortByCol", function() {
+  const df = [
+    { label: "A", value: 7 },
+    { label: "B", value: 2 },
+    { label: "C", value: 75 },
+  ]
+  it("sorts dataframe rows by column name", function() {
+    assert.deepStrictEqual(Z.sortByCol("value", "asc", df), [
+      { label: "B", value: 2 },
+      { label: "A", value: 7 },
+      { label: "C", value: 75 },
+    ])
+  })
+  it("respects order argument", function() {
+    assert.deepStrictEqual(Z.sortByCol("value", "desc", df), [
+      { label: "C", value: 75 },
+      { label: "A", value: 7 },
+      { label: "B", value: 2 },
+    ])
+  })
+})

--- a/test/std.js
+++ b/test/std.js
@@ -1,0 +1,9 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("std", function() {
+  it("returns standard deviation of series", function() {
+    assert.strictEqual(Z.std([7, 2, 30, 56, 75]), 31.36080356113344)
+  })
+})

--- a/test/sum.js
+++ b/test/sum.js
@@ -1,0 +1,11 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("sum", function() {
+  it("sums array of numbers", function() {
+    assert.strictEqual(Z.sum([1, 2, 3, 4, 5]), 15)
+    assert.strictEqual(Z.sum(["1", "2", "3", "4", "5"]), 15)
+    assert.strictEqual(Z.sum([1, 2, "not a number", 4, 5]), 12)
+  })
+})

--- a/test/tail.js
+++ b/test/tail.js
@@ -9,7 +9,9 @@ describe("tail", function() {
       { label: "B", value: "2010-12-15" },
       { label: "C", value: "2010-12-17" },
     ]
-    assert.deepStrictEqual(Z.tail(2, df).length, 2)
-    assert.deepStrictEqual(Z.tail(2, df).find(d => d.label === "A"), undefined)
+    assert.deepStrictEqual(Z.tail(2, df), [
+      { label: "B", value: "2010-12-15" },
+      { label: "C", value: "2010-12-17" },
+    ])
   })
 })

--- a/test/tail.js
+++ b/test/tail.js
@@ -1,0 +1,15 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("tail", function() {
+  it("returns dataframe with last n rows of input dataframe", function() {
+    const df = [
+      { label: "A", value: "2010-12-13" },
+      { label: "B", value: "2010-12-15" },
+      { label: "C", value: "2010-12-17" },
+    ]
+    assert.deepStrictEqual(Z.tail(2, df).length, 2)
+    assert.deepStrictEqual(Z.tail(2, df).find(d => d.label === "A"), undefined)
+  })
+})

--- a/test/toCSV.js
+++ b/test/toCSV.js
@@ -1,0 +1,19 @@
+const path = require("path")
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("toCSV", function() {
+  it("synchronously writes a CSV file", function() {
+    const df = [
+      { label: "C", value: "3" },
+      { label: "B", value: "2" },
+      { label: "A", value: "1" },
+    ]
+    Z.toCSV(path.join(__dirname, "data/test_write.csv"), df)
+    assert.deepStrictEqual(
+      Z.readCSV(path.join(__dirname, "data/test_write.csv")),
+      df
+    )
+  })
+})

--- a/test/unique.js
+++ b/test/unique.js
@@ -1,0 +1,15 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("unique", function() {
+  it("returns unique values in the array", function() {
+    assert.deepStrictEqual(Z.unique([7, 7, 2, 30, 30, 56, 75]), [
+      7,
+      2,
+      30,
+      56,
+      75,
+    ])
+  })
+})

--- a/test/valueCounts.js
+++ b/test/valueCounts.js
@@ -1,0 +1,12 @@
+const assert = require("assert")
+
+const Z = require("../zebras.js")
+
+describe("valueCounts", function() {
+  it("counts numbers of occurences of each value in the array", function() {
+    const c = Z.valueCounts([1, 1, 3])
+    assert.strictEqual(typeof c, "object")
+    assert.strictEqual(c[1], 2)
+    assert.strictEqual(c[3], 1)
+  })
+})

--- a/zebras.js
+++ b/zebras.js
@@ -214,7 +214,7 @@ const tail = (n, df) => {
  * @example
  *
  * const df = [{"label": "A", "value": 2}, {"label": "B", "value": 10}, {"label": "C", "value": 30}]
- * Z.filter(r => r >= 10, df)
+ * Z.filter(r => r.value >= 10, df)
  * // [{"label": "B", "value": 10}, {"label": "C", "value": 30}]
  */
 const filter = R.curry((func, df) => {
@@ -360,7 +360,7 @@ const pickCols = R.curry((cols, df) => {
  * @example
  *
  * const df = [{"label": "A", "value": 7}, {"label": "B", "value": 2}, {"label": "C", "value": 75}]
- * Z.dropCol(["label"], df)
+ * Z.dropCol("label", df)
  * // [{"value": 7}, {"value": 2}, {"value": 75}]
  */
 const dropCol = R.curry((col, df) => {
@@ -827,7 +827,7 @@ const addCol = R.curry((col, arr, df) => {
 })
 
 /**
- * Create a new array based on columns from existing array.
+ * Create a new array based on columns from existing dataframe.
  *
  * Use to create new columns derived from existing columns in a dataframe.
  *
@@ -836,7 +836,7 @@ const addCol = R.curry((col, arr, df) => {
  * @category Manipulation
  * @param {Function} func Function to create the new column
  * @param {df} dataframe Zebras dataframe to add the new column to
- * @return {df}
+ * @return {Array}
  * @example
  *
  * const temps = [{"date": "1990-05-06", "tempCelsius": 0}, {"date": "1990-05-07", "tempCelsius": 4}]


### PR DESCRIPTION
This adds testing setup with mocha and istanbul coverage reporting. It also adds tests for all the Zebras methods. Feel free to tweak them further or suggest any improvements, but I think they give a solid starting point.

![image](https://user-images.githubusercontent.com/998924/51142713-fba53480-184c-11e9-94eb-96990daab4cd.png)

More importantly they already prove very useful, helped me catch some more small bugs in the code.

It would be cool to setup Travis CI to always run these tests on commits/PRs, perhaps also adding coverage badge might help boosting users' confidence a bit. [Here's a nice writeup on that topic](https://maximilianschmitt.me/posts/istanbul-code-coverage-badge-github/).

Closes #17 