### PR TITLE
fix inconsistent example of toCSV.js.html

### DIFF
--- a/docs/toCSV.js.html
+++ b/docs/toCSV.js.html
@@ -59,7 +59,7 @@ import { curry, join, keys, nth, map, values } from "ramda"
  * @return {undefined}
  * @example
  *
- * Z.toCSV(filepath, df)
+ * Z.toCSV(df, filepath)
  */
 const toCSV = curry((filepath, df) => {
   try {


### PR DESCRIPTION
fixes #55 
## ISSUE 55 
## PROBLEM Inconsistent example of Z.toCSV

```
(static) toCSV(df, filepath) → {undefined}
```

> Currently (incorrect)
 
**Example:**
`Z.toCSV(filepath, df)`


> Correctly
 
**Example:**
`Z.toCSV(df, filepath)`
